### PR TITLE
fix: add checkout step to verify-release job

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -181,6 +181,11 @@ jobs:
     if: needs.build-and-tag.outputs.new-tag
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
     - name: Verify tag was created
       run: |
         echo "Verifying tag: ${{ needs.build-and-tag.outputs.new-tag }}"


### PR DESCRIPTION
## Summary
- Fixes the verify-release step error in GitHub Actions run #16424323408
- Adds a checkout step before attempting to use git commands in the verify-release job

## Problem
The verify-release job was failing with an error because it was trying to use `git ls-remote` without having the repository checked out first.

## Solution
Added an `actions/checkout@v4` step at the beginning of the verify-release job to ensure git commands have access to the repository context.

## Test plan
- [x] Pre-commit hooks pass
- [ ] GitHub Actions workflow will validate on merge

🤖 Generated with [Claude Code](https://claude.ai/code)