### PR TITLE
fix(release): address GHA error by force adding dist

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -147,7 +147,7 @@ jobs:
         npm version ${{ steps.bump.outputs.version }} --no-git-tag-version
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git add package.json package-lock.json dist/
+        git add package.json package-lock.json dist/ --force
         git commit -m "chore: bump version to ${{ steps.bump.outputs.version }} and update dist files"
 
     - name: Verify dist files are committed


### PR DESCRIPTION
### Problem

The  GitHub Actions workflow was failing during the 'Update package.json version and commit dist files' step. The error indicated that the  directory, which is intentionally included in the  file, could not be added to the commit.

### Root Cause

The workflow is designed to build the project and commit the resulting  directory as a build artifact for the release tag. However, because  is listed in , the  command within the action was correctly ignoring it, leading to a failed run. We want to keep  in  to prevent developers from committing it from their local environments.

### Solution

This PR resolves the issue by modifying the  workflow. The  flag has been added to the  command.



### Impact

This change allows the GitHub Action to override the local  settings and forcefully add the  directory to the release commit, fixing the workflow. This has no impact on the local development workflow; developers' git clients will continue to ignore the  directory as intended. This is a standard practice for including build artifacts in automated releases without cluttering local development repositories.