### PR TITLE
docs: remove extra blank line in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,4 @@ The action sets the `review_status` output to indicate the result:
 
 ## Contributing
 
-
 Contributions are welcome! Please see `CONTRIBUTING.md` for more information.


### PR DESCRIPTION
## Summary
- Removed extra blank line before Contributing section in README.md

## Test plan
- [x] Visual inspection of README formatting

🤖 Generated with [Claude Code](https://claude.ai/code)