### PR TITLE
fix: improve dist files verification in build-and-tag workflow

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -211,14 +211,34 @@ jobs:
 
     - name: Verify dist files are committed
       run: |
-        echo "Verifying dist files are included in the latest commit..."
-        git show --name-only HEAD | grep -E "^dist/" || {
-          echo "ERROR: dist files not found in latest commit"
-          echo "Files in latest commit:"
-          git show --name-only HEAD
+        echo "Verifying dist files are properly handled..."
+
+        # Check if dist files exist in working directory
+        if [ ! -f "dist/index.js" ]; then
+          echo "ERROR: dist/index.js not found in working directory"
           exit 1
-        }
-        echo "✅ dist files successfully committed"
+        fi
+
+        # Check if dist files are in the latest commit OR unchanged since last commit
+        if git show --name-only HEAD | grep -E "^dist/" > /dev/null; then
+          echo "✅ dist files found in latest commit"
+        else
+          echo "dist files not in latest commit, checking if they're unchanged..."
+
+          # Check if dist files have any uncommitted changes
+          if git diff --quiet HEAD -- dist/; then
+            echo "✅ dist files are up-to-date (no changes since last commit)"
+          else
+            echo "ERROR: dist files have uncommitted changes but weren't included in commit"
+            echo "Files in latest commit:"
+            git show --name-only HEAD
+            echo "Uncommitted dist changes:"
+            git diff --name-only HEAD -- dist/
+            exit 1
+          fi
+        fi
+
+        echo "✅ dist files verification passed"
 
     - name: Push version update
       run: git push origin main


### PR DESCRIPTION
## Summary
- Fix false failure when dist files haven't changed since last commit
- Add intelligent verification that checks if dist files exist and are either in the latest commit (if changed) or up-to-date with no uncommitted changes (if unchanged)
- Resolves GHA run #16525916039 where verification failed for unchanged dist files

## Root Cause
The "Verify dist files are committed" step was failing because it only checked if dist files were present in the latest commit. However, when dist files don't change between builds (because the TypeScript source didn't change), they won't be included in the version bump commit, causing a false failure.

## Solution
Updated the verification logic in `.github/workflows/build-and-tag.yml` to:
1. Check if dist files exist in working directory (basic sanity check)
2. Accept dist files either:
   - In the latest commit (if they changed and were committed), OR
   - Up-to-date with no uncommitted changes (if they're already current)
3. Provide better error messages and diagnostics for debugging

## Test Plan
- [x] Workflow file passes YAML linting
- [x] All tests pass
- [x] Pre-commit hooks pass
- [ ] Verify workflow runs successfully on merge

🤖 Generated with [Claude Code](https://claude.ai/code)